### PR TITLE
Feat - Support for prompts when CLI is missing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
     # Type check
     - id: pyright
       name: pyright
-      entry: uv run --all-extras pyright clypi
+      entry: uv run --all-extras pyright clypi/ pyright_tests/
       language: python
       types: [python]
       exclude: ^tests/.*

--- a/clypi/_cli/config.py
+++ b/clypi/_cli/config.py
@@ -2,14 +2,14 @@ import typing as t
 from dataclasses import asdict, dataclass
 
 from clypi._util import _UNSET, Unset
-from clypi.prompts import MAX_ATTEMPTS
+from clypi.prompts import MAX_ATTEMPTS, Parser
 
 T = t.TypeVar("T")
 
 
 @dataclass
 class PartialConfig(t.Generic[T]):
-    parser: t.Callable[[t.Any], T] | None = None
+    parser: Parser[T] | None = None
     default: T | Unset = _UNSET
     default_factory: t.Callable[[], T] | Unset = _UNSET
     help: str | None = None
@@ -33,7 +33,7 @@ class PartialConfig(t.Generic[T]):
 
 @dataclass
 class Config(t.Generic[T]):
-    parser: t.Callable[[t.Any], T]
+    parser: Parser[T]
     arg_type: t.Any
     default: T | Unset = _UNSET
     default_factory: t.Callable[[], T] | Unset = _UNSET
@@ -57,7 +57,7 @@ class Config(t.Generic[T]):
 
     @classmethod
     def from_partial(
-        cls, partial: PartialConfig[T], parser: t.Callable[[t.Any], T], arg_type: t.Any
+        cls, partial: PartialConfig[T], parser: Parser[T], arg_type: t.Any
     ):
         kwargs = asdict(partial)
         kwargs.update(parser=parser, arg_type=arg_type)
@@ -65,7 +65,7 @@ class Config(t.Generic[T]):
 
 
 def config(
-    parser: t.Callable[[t.Any], T] | None = None,
+    parser: Parser[T] | None = None,
     default: T | Unset = _UNSET,
     default_factory: t.Callable[[], T] | Unset = _UNSET,
     help: str | None = None,

--- a/clypi/_cli/config.py
+++ b/clypi/_cli/config.py
@@ -1,33 +1,32 @@
 import typing as t
 from dataclasses import asdict, dataclass
 
+from clypi._util import _UNSET, Unset
+from clypi.prompts import MAX_ATTEMPTS
+
 T = t.TypeVar("T")
-
-
-class _MISSING_TYPE:
-    pass
-
-
-MISSING = _MISSING_TYPE()
 
 
 @dataclass
 class PartialConfig(t.Generic[T]):
     parser: t.Callable[[t.Any], T] | None = None
-    default: T | _MISSING_TYPE = MISSING
-    default_factory: t.Callable[[], T] | _MISSING_TYPE = MISSING
+    default: T | Unset = _UNSET
+    default_factory: t.Callable[[], T] | Unset = _UNSET
     help: str | None = None
     short: str | None = None
+    prompt: str | None = None
+    hide_input: bool = False
+    max_attempts: int = MAX_ATTEMPTS
 
     def has_default(self) -> bool:
-        return self.default is not MISSING or self.default_factory is not MISSING
+        return self.default is not _UNSET or self.default_factory is not _UNSET
 
     def get_default(self) -> T:
-        if not isinstance(self.default, _MISSING_TYPE):
+        if not isinstance(self.default, Unset):
             return self.default
 
         if t.TYPE_CHECKING:
-            assert not isinstance(self.default_factory, _MISSING_TYPE)
+            assert not isinstance(self.default_factory, Unset)
 
         return self.default_factory()
 
@@ -36,24 +35,25 @@ class PartialConfig(t.Generic[T]):
 class Config(t.Generic[T]):
     parser: t.Callable[[t.Any], T]
     arg_type: t.Any
-    default: T | _MISSING_TYPE = MISSING
-    default_factory: t.Callable[[], T] | _MISSING_TYPE = MISSING
+    default: T | Unset = _UNSET
+    default_factory: t.Callable[[], T] | Unset = _UNSET
     help: str | None = None
     short: str | None = None
+    prompt: str | None = None
+    hide_input: bool = False
+    max_attempts: int = MAX_ATTEMPTS
 
     def has_default(self) -> bool:
-        return not isinstance(self.default, _MISSING_TYPE) or not isinstance(
-            self.default_factory, _MISSING_TYPE
+        return not isinstance(self.default, Unset) or not isinstance(
+            self.default_factory, Unset
         )
 
-    def get_default(self) -> T:
-        if not isinstance(self.default, _MISSING_TYPE):
+    def get_default(self) -> T | Unset:
+        if not isinstance(self.default, Unset):
             return self.default
-
-        if t.TYPE_CHECKING:
-            assert not isinstance(self.default_factory, _MISSING_TYPE)
-
-        return self.default_factory()
+        if not isinstance(self.default_factory, Unset):
+            return self.default_factory()
+        return _UNSET
 
     @classmethod
     def from_partial(
@@ -66,10 +66,13 @@ class Config(t.Generic[T]):
 
 def config(
     parser: t.Callable[[t.Any], T] | None = None,
-    default: T | _MISSING_TYPE = MISSING,
-    default_factory: t.Callable[[], T] | _MISSING_TYPE = MISSING,
+    default: T | Unset = _UNSET,
+    default_factory: t.Callable[[], T] | Unset = _UNSET,
     help: str | None = None,
     short: str | None = None,
+    prompt: str | None = None,
+    hide_input: bool = False,
+    max_attempts: int = MAX_ATTEMPTS,
 ) -> T:
     return PartialConfig(
         parser=parser,
@@ -77,4 +80,7 @@ def config(
         default_factory=default_factory,
         help=help,
         short=short,
+        prompt=prompt,
+        hide_input=hide_input,
+        max_attempts=max_attempts,
     )  # type: ignore

--- a/clypi/_cli/formatter.py
+++ b/clypi/_cli/formatter.py
@@ -8,7 +8,7 @@ from clypi import boxed, stack
 from clypi._cli import type_util
 
 if t.TYPE_CHECKING:
-    from clypi.cli import Argument, SubCommand
+    from clypi.cli import _Argument, _SubCommand
 
 
 @dataclass
@@ -44,12 +44,12 @@ class TermFormatter:
     prog: list[str]
     description: str | None
     epilog: str | None
-    options: list[Argument]
-    positionals: list[Argument]
-    subcommands: list[SubCommand]
+    options: list[_Argument]
+    positionals: list[_Argument]
+    subcommands: list[_SubCommand]
     exception: Exception | None
 
-    def _format_option(self, option: Argument) -> tuple[str, ...]:
+    def _format_option(self, option: _Argument) -> tuple[str, ...]:
         usage = clypi.style(option.display_name, fg="blue", bold=True)
         short_usage = (
             clypi.style(option.short_display_name, fg="green", bold=True)
@@ -82,7 +82,7 @@ class TermFormatter:
             )
         )
 
-    def _format_positional(self, positional: Argument) -> t.Any:
+    def _format_positional(self, positional: _Argument) -> t.Any:
         name = clypi.style(positional.name, fg="blue", bold=True)
         help = positional.help or ""
         type_str = clypi.style(
@@ -102,9 +102,9 @@ class TermFormatter:
             name.append(n)
             type_str.append(ts)
             help.append(hp)
-        return list(boxed(stack(name, type_str, help, lines=True), title="Arguments"))
+        return list(boxed(stack(name, type_str, help, lines=True), title="_Arguments"))
 
-    def _format_subcommand(self, subcmd: SubCommand) -> t.Any:
+    def _format_subcommand(self, subcmd: _SubCommand) -> t.Any:
         name = clypi.style(subcmd.name, fg="blue", bold=True)
         help = subcmd.help or ""
         return name, help

--- a/clypi/_cli/parser.py
+++ b/clypi/_cli/parser.py
@@ -200,7 +200,7 @@ class CurrentCtx:
     nargs: Nargs = 0
     max_nargs: Nargs = 0
 
-    _collected: list[t.Any] = field(init=False, default_factory=list)
+    _collected: list[str] = field(init=False, default_factory=list)
 
     def has_more(self) -> bool:
         if isinstance(self.nargs, float | int):
@@ -214,7 +214,7 @@ class CurrentCtx:
             return True
         return False
 
-    def collect(self, item: t.Any) -> None:
+    def collect(self, item: str) -> None:
         if isinstance(self.nargs, float | int):
             self.nargs -= 1
         elif self.nargs == "+":
@@ -223,7 +223,7 @@ class CurrentCtx:
         self._collected.append(item)
 
     @property
-    def collected(self) -> t.Any:
+    def collected(self) -> str | list[str]:
         if self.max_nargs == 1:
             return self._collected[0]
         return self._collected

--- a/clypi/_util.py
+++ b/clypi/_util.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from enum import Enum, auto
+
+
+class Unset(Enum):
+    TOKEN = auto()
+
+
+_UNSET = Unset.TOKEN

--- a/clypi/cli.py
+++ b/clypi/cli.py
@@ -14,6 +14,8 @@ from Levenshtein import distance  # type: ignore
 from clypi._cli import config as _conf
 from clypi._cli import parser, type_util
 from clypi._cli.formatter import TermFormatter
+from clypi._util import _UNSET
+from clypi.prompts import prompt
 
 logger = logging.getLogger(__name__)
 
@@ -26,7 +28,7 @@ def _camel_to_dashed(s: str):
 
 
 @dataclass
-class Argument:
+class _Argument:
     name: str
     arg_type: t.Any
     help: str | None
@@ -62,21 +64,16 @@ class Argument:
 
 
 @dataclass
-class SubCommand:
+class _SubCommand:
     name: str
     klass: type[Command]
-    help: str
+    help: str | None
 
 
 class Command:
-    @t.final
-    @classmethod
-    def name(cls):
-        return _camel_to_dashed(cls.__name__)
-
     @classmethod
     def prog(cls) -> str:
-        return cls.name()
+        return _camel_to_dashed(cls.__name__)
 
     @classmethod
     def epilog(cls) -> str | None:
@@ -125,7 +122,7 @@ class Command:
         """
         defaults: dict[str, _conf.Config[t.Any]] = {}
         for field, _type in inspect.get_annotations(cls).items():
-            default = getattr(cls, field, _conf.MISSING)
+            default = getattr(cls, field, _UNSET)
             if isinstance(default, _conf.PartialConfig):
                 defaults[field] = _conf.Config.from_partial(
                     default,
@@ -142,7 +139,7 @@ class Command:
 
     @t.final
     @classmethod
-    def _next_positional(cls, kwargs: dict[str, t.Any]) -> Argument | None:
+    def _next_positional(cls, kwargs: dict[str, t.Any]) -> _Argument | None:
         """
         Traverse the current collected arguments and find the next positional
         arg we can assign to.
@@ -296,11 +293,20 @@ class Command:
         # Parse as the correct values and assign to the instance
         instance = cls()
         for field, field_conf in cls.fields().items():
-            if field not in kwargs and not field_conf.has_default():
+            # Get the value passed in, prompt, or the provided default
+            if field in kwargs:
+                value = kwargs[field]
+            elif field_conf.prompt is not None:
+                value = prompt(
+                    field_conf.prompt,
+                    default=field_conf.get_default(),
+                    hide_input=field_conf.hide_input,
+                    max_attempts=field_conf.max_attempts,
+                )
+            elif field_conf.has_default():
+                value = field_conf.get_default()
+            else:
                 raise ValueError(f"Missing required argument {field}")
-
-            # Get the value passed in or the provided default
-            value = kwargs[field] if field in kwargs else field_conf.get_default()
 
             # Subcommands are already parsed properly
             if field == "subcommand":
@@ -315,32 +321,39 @@ class Command:
 
     @t.final
     @classmethod
-    def subcommands(cls) -> dict[str, SubCommand]:
+    def subcommands(cls) -> dict[str, _SubCommand]:
         if "subcommand" not in cls.fields():
             return {}
 
         # Get the subcommand type/types
         _type = cls.fields()["subcommand"].arg_type
-        subcmds = [_type]
+        subcmds_tmp = [_type]
         if isinstance(_type, UnionType):
-            subcmds = [s for s in _type.__args__ if s is not NoneType]
+            subcmds_tmp = [s for s in _type.__args__ if s is not NoneType]
 
-        for v in subcmds:
+        subcmds: list[type[Command]] = []
+        for v in subcmds_tmp:
             assert inspect.isclass(v) and issubclass(v, Command)
+            subcmds.append(v)
 
         return {
-            s.name(): SubCommand(name=s.name(), klass=s, help=s.help()) for s in subcmds
+            s.prog(): _SubCommand(name=s.prog(), klass=s, help=s.help())
+            for s in subcmds
         }
 
     @t.final
     @classmethod
-    def options(cls) -> dict[str, Argument]:
-        options: dict[str, Argument] = {}
+    def options(cls) -> dict[str, _Argument]:
+        options: dict[str, _Argument] = {}
         for field, field_conf in cls.fields().items():
-            if field == "subcommand" or not field_conf.has_default():
+            if field == "subcommand":
                 continue
 
-            options[field] = Argument(
+            # Is positional
+            if not field_conf.has_default() and field_conf.prompt is None:
+                continue
+
+            options[field] = _Argument(
                 field,
                 type_util.remove_optionality(field_conf.arg_type),
                 help=field_conf.help,
@@ -351,13 +364,17 @@ class Command:
 
     @t.final
     @classmethod
-    def positionals(cls) -> dict[str, Argument]:
-        options: dict[str, Argument] = {}
+    def positionals(cls) -> dict[str, _Argument]:
+        options: dict[str, _Argument] = {}
         for field, field_conf in cls.fields().items():
-            if field == "subcommand" or field_conf.has_default():
+            if field == "subcommand":
                 continue
 
-            options[field] = Argument(
+            # Is option
+            if field_conf.has_default() or field_conf.prompt is not None:
+                continue
+
+            options[field] = _Argument(
                 field,
                 field_conf.arg_type,
                 help=field_conf.help,

--- a/clypi/prompts.py
+++ b/clypi/prompts.py
@@ -24,7 +24,7 @@ class MaxAttemptsException(Exception):
 
 T = t.TypeVar("T")
 
-Parser: t.TypeAlias = t.Callable[[str | list[str]], T]
+Parser: t.TypeAlias = t.Callable[[t.Any], T]
 
 
 def prompt(

--- a/clypi/prompts.py
+++ b/clypi/prompts.py
@@ -1,17 +1,10 @@
 from __future__ import annotations
 
 import typing as t
-from enum import Enum, auto
 from getpass import getpass
 
 import clypi
-
-
-class Unset(Enum):
-    TOKEN = auto()
-
-
-_UNSET = Unset.TOKEN
+from clypi._util import _UNSET, Unset
 
 MAX_ATTEMPTS: int = 20
 

--- a/clypi/prompts.py
+++ b/clypi/prompts.py
@@ -24,7 +24,7 @@ class MaxAttemptsException(Exception):
 
 T = t.TypeVar("T")
 
-Parser: t.TypeAlias = t.Callable[[str], T]
+Parser: t.TypeAlias = t.Callable[[str | list[str]], T]
 
 
 def prompt(

--- a/docs/index.md
+++ b/docs/index.md
@@ -411,10 +411,11 @@ Examples:
 ### `Parser[T]`
 
 ```python
-Parser: t.TypeAlias = t.Callable[[str], T]
+Parser: TypeAlias = Callable[[Any], T]
 ```
-A function taking in any value as a string and returning a value of type `T`. This parser
-can be a user defined function, a built-in type like `str`, `int`, etc., or a parser from a library.
+A function taking in any value and returns a value of type `T`. This parser
+can be a user defined function, a built-in type like `str`, `int`, etc., or a parser
+from a library.
 
 ### `prompt`
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -211,24 +211,13 @@ class MyCli(Command):
     files: list[Path] = config(parser=v6e.path().exists().list())
 ```
 
-
-#### `name`
-
-```python
-@t.final
-@classmethod
-def name(cls)
-```
-The name of the command displayed to the user. Can be overriden to provide a custom name
-or will default to the class name extending `Command`.
-
 #### `prog`
 ```python
 @t.final
 @classmethod
 def prog(cls)
 ```
-The name of the command the user must pass in. Can be overriden to provide a custom name
+The name of the command. Can be overriden to provide a custom name
 or will default to the class name extending `Command`.
 
 #### `help`

--- a/docs/index.md
+++ b/docs/index.md
@@ -68,6 +68,34 @@ Examples:
 
 ## CLI
 
+### `config`
+
+```python
+def config(
+    parser: Parser[T] | None = None,
+    default: T | Unset = _UNSET,
+    default_factory: t.Callable[[], T] | Unset = _UNSET,
+    help: str | None = None,
+    short: str | None = None,
+    prompt: str | None = None,
+    hide_input: bool = False,
+    max_attempts: int = MAX_ATTEMPTS,
+) -> T
+```
+
+Utility function to configure how a specific argument should behave when displayed
+and parsed.
+
+Parameters:
+- `parser`: a function that takes in a string and returns the parsed type (see [`Parser`](#parser[t]))
+- `default`: the default value to return if the user doesn't pass in the argument (or hits enter during the prompt, if any)
+- `default_factory`: a function that returns a default value. Useful to defer computation or to avoid default mutable values
+- `help`: a brief description to show the user when they pass in `-h` or `--help`
+- `short`: for options it defines a short way to pass in a value (e.g.: `short="v"` allows users to pass in `-v <value>`)
+- `prompt`: if defined, it will ask the user to provide input if not already defined in the command line args
+- `hide_input`: wether the input shouldn't be displayed as the user types (for passwords, API keys, etc.)
+- `max_attempts`: how many times to ask the user before giving up and raising
+
 ### `Command`
 
 This is the main class you must extend when defining a command. There are no methods you must override
@@ -182,6 +210,19 @@ class MyCommand(Command):
     and can contain any info you'd like
     """
 ```
+
+#### Prompting
+
+If you want to ask the user to provide input if it's not specified, you can pass in a prompt to `config` for each field like so:
+
+```python
+from clypi import Command, config
+
+class MyCommand(Command):
+    name: str = config(prompt="What's your name?")
+```
+
+On runtime, if the user didn't provide a value for `--name`, the program will ask the user to provide one until they do. You can also pass in a `default` value to `config` to allow the user to just hit enter to accept the default.
 
 #### Custom parsers
 

--- a/examples/basic_cli.py
+++ b/examples/basic_cli.py
@@ -2,6 +2,10 @@ from clypi import Command, config
 
 
 class Lint(Command):
+    """
+    A basic example of clypi's subcommands
+    """
+
     files: tuple[str, ...]
 
     async def run(self, root):
@@ -9,11 +13,16 @@ class Lint(Command):
 
 
 class MyCli(Command):
+    """
+    A basic example of clypi
+    """
+
     subcommand: Lint | None = None
     verbose: bool = config(short="v", default=False)
+    name: str = config(prompt="What's your name?", help="The name of the user")
 
     async def run(self, root):
-        print(f"Running the main command with {self.verbose}")
+        print(f"Running the main command with {self.verbose} and {self.name}")
 
 
 if __name__ == "__main__":

--- a/examples/cli.py
+++ b/examples/cli.py
@@ -91,6 +91,7 @@ class Lint(Command):
     index: str = config(
         default="http://pypi.org",
         help="The index to download termuff from",
+        prompt="What index do you want to download termuff from?",
     )
 
     @debug

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "clypi"
 description = "Your all-in-one for beautiful, lightweight, prod-ready CLIs"
 readme = "README.md"
-version = "0.1.8"
+version = "0.1.9"
 license = "MIT"
 license-files = ["LICEN[CS]E*"]
 requires-python = "~=3.11,<3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11, <3.13"
 
 [[package]]
 name = "clypi"
-version = "0.1.8"
+version = "0.1.9"
 source = { editable = "." }
 dependencies = [
     { name = "levenshtein" },


### PR DESCRIPTION
See changes to docs. The TLDR is that `config` now takes in similar arguments to `clypi.prompt` and will ask the user for a value if none is provided.