### PR TITLE
Feat - Arg forwarding configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,10 @@ from clypi import Command, config
 
 class Lint(Command):
     files: tuple[str, ...]
+    verbose = config(forwarded=True)  # Comes from MyCli but I want to use it too
 
     async def run(self):
-        print(f"Linting {', '.join(self.files)}")
+        print(f"Linting {', '.join(self.files)} and {self.verbose=}")
 
 class MyCli(Command):
     """
@@ -52,7 +53,7 @@ class MyCli(Command):
         help="Wether to show extra logs",
         prompt="Do you want to see extra logs?",
         default=False,
-        short="v",
+        short="v",  # User can pass in --verbose or -v
     )
 
     async def run(self):

--- a/clypi/_cli/config.py
+++ b/clypi/_cli/config.py
@@ -17,6 +17,7 @@ class PartialConfig(t.Generic[T]):
     prompt: str | None = None
     hide_input: bool = False
     max_attempts: int = MAX_ATTEMPTS
+    forwarded: bool = False
 
     def has_default(self) -> bool:
         return self.default is not _UNSET or self.default_factory is not _UNSET
@@ -42,13 +43,20 @@ class Config(t.Generic[T]):
     prompt: str | None = None
     hide_input: bool = False
     max_attempts: int = MAX_ATTEMPTS
+    forwarded: bool = False
 
     def has_default(self) -> bool:
         return not isinstance(self.default, Unset) or not isinstance(
             self.default_factory, Unset
         )
 
-    def get_default(self) -> T | Unset:
+    def get_default(self) -> T:
+        val = self.get_default_or_missing()
+        if isinstance(val, Unset):
+            raise ValueError(f"Field {self} has no default value!")
+        return val
+
+    def get_default_or_missing(self) -> T | Unset:
         if not isinstance(self.default, Unset):
             return self.default
         if not isinstance(self.default_factory, Unset):
@@ -73,6 +81,7 @@ def config(
     prompt: str | None = None,
     hide_input: bool = False,
     max_attempts: int = MAX_ATTEMPTS,
+    forwarded: bool = False,
 ) -> T:
     return PartialConfig(
         parser=parser,
@@ -83,4 +92,5 @@ def config(
         prompt=prompt,
         hide_input=hide_input,
         max_attempts=max_attempts,
+        forwarded=forwarded,
     )  # type: ignore

--- a/clypi/cli.py
+++ b/clypi/cli.py
@@ -90,24 +90,21 @@ class Command:
 
         return doc.replace("\n", " ")
 
-    async def run(self, root: Command) -> None:
+    async def run(self) -> None:
         """
         This function is where the business logic of your command
         should live.
 
         `self` contains the arguments for this command you can access
-        as any other instance property.
-
-        `root` is a pointer to the base command of your CLI so that you
-        can access arguments passed to parent commands.
+        as you would do with any other instance property.
         """
         raise NotImplementedError
 
     @t.final
-    async def astart(self, root: Command | None = None) -> None:
+    async def astart(self) -> None:
         if subcommand := getattr(self, "subcommand", None):
-            return await subcommand.astart(root=root or self)
-        return await self.run(root or self)
+            return await subcommand.astart()
+        return await self.run()
 
     @t.final
     def start(self) -> None:

--- a/docs/index.md
+++ b/docs/index.md
@@ -185,7 +185,7 @@ from clypi import Command, config
 class MyCommand(Command):
     verbose: bool = config(help="Wether to show all of the output", default=True)
 
-    async def run(self, root):
+    async def run(self):
         print(f"Running with verbose: {self.verbose}")
 ```
 
@@ -272,21 +272,18 @@ docstring for the class extending `Command`.
 
 #### `run`
 ```python
-async def run(self, root: Command) -> None:
+async def run(self: Command) -> None:
 ```
 The main function you **must** override. This function is where the business logic of your command
 should live.
 
 `self` contains the arguments for this command you can access
-as any other instance property.
-
-`root` is a pointer to the base command of your CLI so that you
-can access arguments passed to parent commands.
+as you would do with any other instance property.
 
 
 #### `astart` and `start`
 ```python
-async def astart(self, root: Command | None = None) -> None:
+async def astart(self: Command | None = None) -> None:
 ```
 ```python
 def start(self) -> None:

--- a/examples/basic_cli.py
+++ b/examples/basic_cli.py
@@ -3,9 +3,10 @@ from clypi import Command, config
 
 class Lint(Command):
     files: tuple[str, ...]
+    verbose: bool = config(forwarded=True)  # Comes from MyCli but I want to use it too
 
     async def run(self):
-        print(f"Linting {', '.join(self.files)}")
+        print(f"Linting {', '.join(self.files)} and {self.verbose=}")
 
 
 class MyCli(Command):
@@ -18,7 +19,7 @@ class MyCli(Command):
         help="Wether to show extra logs",
         prompt="Do you want to see extra logs?",
         default=False,
-        short="v",
+        short="v",  # User can pass in --verbose or -v
     )
 
     async def run(self):

--- a/examples/basic_cli.py
+++ b/examples/basic_cli.py
@@ -4,7 +4,7 @@ from clypi import Command, config
 class Lint(Command):
     files: tuple[str, ...]
 
-    async def run(self, root):
+    async def run(self):
         print(f"Linting {', '.join(self.files)}")
 
 
@@ -21,7 +21,7 @@ class MyCli(Command):
         short="v",
     )
 
-    async def run(self, root):
+    async def run(self):
         print(f"Running the main command with {self.verbose}")
 
 

--- a/examples/cli.py
+++ b/examples/cli.py
@@ -11,16 +11,16 @@ from clypi import Command, config
 
 def debug(fun):
     """
-    Just a utility decorator to display the root commands being passed in a somewhat
+    Just a utility decorator to display the commands being passed in a somewhat
     nice way
     """
 
-    async def inner(self, root):
+    async def inner(self):
         boxed = clypi.boxed(
-            clypi.style(root, bold=True), title="Debug", color="magenta"
+            clypi.style(self, bold=True), title="Debug", color="magenta"
         )
         print(boxed, end="\n\n")
-        await fun(self, root)
+        await fun(self)
 
     return inner
 
@@ -37,7 +37,7 @@ class RunParallel(Command):
     )
 
     @debug
-    async def run(self, root):
+    async def run(self):
         clypi.print("Running all files", fg="blue", bold=True)
 
         async with clypi.Spinner(f"Running {', '.join(self.files)} in parallel"):
@@ -57,7 +57,7 @@ class RunSerial(Command):
     files: list[Path] = config(parser=v.list(v.path().exists()))
 
     @debug
-    async def run(self, root):
+    async def run(self):
         clypi.print("Running all files", fg="blue", bold=True)
         for f in self.files:
             async with clypi.Spinner(f"Running {f.as_posix()} in parallel"):
@@ -95,7 +95,7 @@ class Lint(Command):
     )
 
     @debug
-    async def run(self, root):
+    async def run(self):
         async with clypi.Spinner(f"Linting {', '.join(self.files)}"):
             await asyncio.sleep(2)
         clypi.print("\nDone!", fg="green", bold=True)
@@ -121,7 +121,7 @@ class Main(Command):
         return "Learn more at http://termuff.org"
 
     @debug
-    async def run(self, root):
+    async def run(self):
         self.print_help()
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "clypi"
 description = "Your all-in-one for beautiful, lightweight, prod-ready CLIs"
 readme = "README.md"
-version = "0.1.9"
+version = "0.1.10"
 license = "MIT"
 license-files = ["LICEN[CS]E*"]
 requires-python = "~=3.11,<3.13"

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -12,7 +12,7 @@ class ExampleSubCommand(Command):
 
     positional: tuple[str | Path, ...]
 
-    async def run(self, root):
+    async def run(self):
         return "subcommand"
 
 
@@ -35,7 +35,7 @@ class ExampleCommand(Command):
     def epilog(cls):
         return "Some text to display after..."
 
-    async def run(self, root):
+    async def run(self):
         return "main"
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11, <3.13"
 
 [[package]]
 name = "clypi"
-version = "0.1.9"
+version = "0.1.10"
 source = { editable = "." }
 dependencies = [
     { name = "levenshtein" },


### PR DESCRIPTION
Introduces a new `config(forwarded=True)` that allows you to read arguments parsed by parent commands. This approach is better than the previous `root` approach since `root` could not be properly type hinted.