### PR TITLE
Feat - hide options from help

### DIFF
--- a/clypi/_cli/context.py
+++ b/clypi/_cli/context.py
@@ -1,7 +1,6 @@
-import typing as t
 from dataclasses import dataclass, field
 
-Nargs: t.TypeAlias = t.Literal["*", "+"] | float
+from clypi._cli.config import Nargs
 
 
 @dataclass

--- a/clypi/_cli/type_util.py
+++ b/clypi/_cli/type_util.py
@@ -1,7 +1,7 @@
 import inspect
 import typing as t
 from enum import Enum
-from types import UnionType
+from types import NoneType, UnionType
 
 P = t.ParamSpec("P")
 R = t.TypeVar("R")
@@ -76,7 +76,7 @@ def tuple_size(_type: t.Any) -> float:
 
 @ignore_annotated
 def is_none(_type: t.Any) -> t.TypeGuard[type[None]]:
-    return _type is None
+    return _type is NoneType
 
 
 @ignore_annotated

--- a/examples/uv/__main__.py
+++ b/examples/uv/__main__.py
@@ -19,6 +19,7 @@ class Uv(Command):
     no_cache: bool = arg(
         default=False,
         help="Avoid reading from or writing to the cache, instead using a temporary directory for the duration of the operation",
+        hidden=True,
     )
 
     async def run(self) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "clypi"
 description = "Your all-in-one for beautiful, lightweight, prod-ready CLIs"
 readme = "README.md"
-version = "1.0.8"
+version = "1.0.9"
 license = "MIT"
 license-files = ["LICEN[CS]E*"]
 requires-python = ">=3.11"

--- a/tests/parsers_test.py
+++ b/tests/parsers_test.py
@@ -152,6 +152,7 @@ def test_successfull_two_item_tuple_parsers(
         (int | bool | str, cp.Int() | cp.Bool() | cp.Str()),
         (t.Literal[1, "foo"], cp.Literal("1", "foo")),
         (Color, cp.Enum(Color)),
+        (int | None, cp.Union(cp.Int(), cp.NoneParser())),
     ],
 )
 def test_parser_from_type(_type: t.Any, expected: cp.Parser[t.Any]):

--- a/uv.lock
+++ b/uv.lock
@@ -18,7 +18,7 @@ wheels = [
 
 [[package]]
 name = "clypi"
-version = "1.0.8"
+version = "1.0.9"
 source = { editable = "." }
 dependencies = [
     { name = "python-dateutil" },


### PR DESCRIPTION
You can now use the following code to hide some options from the help menu:

```python
class Foo(Command):
    option: arg(hidden=True)
```