### PR TITLE
Bug - Fix Pyright's `reportUnitializedClassVariable` error & switch to strict

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,6 @@ jobs:
       - name: "Python type checking -- Pyright"
         run: uv run --all-extras pyright clypi/ type_tests/ examples/
 
-      - name: "Python type checking -- Mypy"
-        run: uv run --all-extras mypy clypi/ type_tests/ examples/
-
       - name: "Codespell"
         run: uv run --all-extras codespell
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,3 @@
-ci:
-  skip: [pytest]
-
 repos:
   - repo: https://github.com/astral-sh/uv-pre-commit
     # uv version.
@@ -19,6 +16,7 @@ repos:
       exclude: ^tests/.*
       pass_filenames: false
       always_run: true
+      stages: [pre-push]
 
     # Run tests
     - id: pytest
@@ -62,6 +60,7 @@ repos:
       language: python
       pass_filenames: false
       always_run: true
+      stages: [pre-push]
 
     # Markdown tests
     - id: mdtest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,14 +19,6 @@ repos:
       exclude: ^tests/.*
       pass_filenames: false
       always_run: true
-    - id: mypy
-      name: mypy
-      entry: uv run --all-extras mypy clypi/ type_tests/ examples/
-      language: python
-      types: [python]
-      exclude: ^tests/.*
-      pass_filenames: false
-      always_run: true
 
     # Run tests
     - id: pytest

--- a/clypi/_cli/formatter.py
+++ b/clypi/_cli/formatter.py
@@ -33,8 +33,8 @@ class Formatter(t.Protocol):
         prog: list[str],
         description: str | None,
         epilog: str | None,
-        options: list[Config],
-        positionals: list[Config],
+        options: list[Config[t.Any]],
+        positionals: list[Config[t.Any]],
         subcommands: list[type[Command]],
         exception: Exception | None,
     ) -> str: ...
@@ -82,13 +82,13 @@ class ClypiFormatter:
         stacked = stack(first_col, *rest, lines=True)
         return list(boxed(stacked, width="max", title=title, color=color))
 
-    def _format_option_value(self, option: Config):
+    def _format_option_value(self, option: Config[t.Any]):
         if option.nargs == 0:
             return ""
         placeholder = dash_to_snake(option.name).upper()
         return self.theme.placeholder(f"<{placeholder}>")
 
-    def _format_option(self, option: Config) -> tuple[str, ...]:
+    def _format_option(self, option: Config[t.Any]) -> tuple[str, ...]:
         help = self._maybe_norm_help(option.help or "")
 
         # E.g.: -r, --requirements <REQUIREMENTS>
@@ -112,7 +112,7 @@ class ClypiFormatter:
 
         return usage, type_str, help
 
-    def _format_options(self, options: list[Config]) -> list[str] | None:
+    def _format_options(self, options: list[Config[t.Any]]) -> list[str] | None:
         if not options:
             return None
 
@@ -131,13 +131,13 @@ class ClypiFormatter:
 
         return self._maybe_boxed(usage, type_str, help, title="Options")
 
-    def _format_positional_with_mod(self, positional: Config) -> str:
+    def _format_positional_with_mod(self, positional: Config[t.Any]) -> str:
         # E.g.: [FILES]...
         pos_name = positional.name.upper()
         name = f"[{pos_name}]{positional.modifier}"
         return name
 
-    def _format_positional(self, positional: Config) -> tuple[str, ...]:
+    def _format_positional(self, positional: Config[t.Any]) -> tuple[str, ...]:
         # E.g.: [FILES]... or FILES
         name = (
             self.theme.positional(self._format_positional_with_mod(positional))
@@ -153,7 +153,9 @@ class ClypiFormatter:
         )
         return name, type_str, self._maybe_norm_help(help)
 
-    def _format_positionals(self, positionals: list[Config]) -> list[str] | str | None:
+    def _format_positionals(
+        self, positionals: list[Config[t.Any]]
+    ) -> list[str] | str | None:
         if not positionals:
             return None
 
@@ -191,8 +193,8 @@ class ClypiFormatter:
     def _format_header(
         self,
         prog: list[str],
-        options: list[Config],
-        positionals: list[Config],
+        options: list[Config[t.Any]],
+        positionals: list[Config[t.Any]],
         subcommands: list[type[Command]],
     ) -> list[str] | str | None:
         prefix = self.theme.usage("Usage:")
@@ -201,7 +203,7 @@ class ClypiFormatter:
         option = self.theme.prog_args(" [OPTIONS]") if options else ""
         command = self.theme.prog_args(" COMMAND") if subcommands else ""
 
-        positionals_str = []
+        positionals_str: list[str] = []
         for pos in positionals:
             name = self._format_positional_with_mod(pos)
             positionals_str.append(self.theme.prog_args(name))
@@ -238,8 +240,8 @@ class ClypiFormatter:
         prog: list[str],
         description: str | None,
         epilog: str | None,
-        options: list[Config],
-        positionals: list[Config],
+        options: list[Config[t.Any]],
+        positionals: list[Config[t.Any]],
         subcommands: list[type[Command]],
         exception: Exception | None,
     ) -> str:

--- a/clypi/cli.py
+++ b/clypi/cli.py
@@ -59,7 +59,7 @@ class _CommandMeta(type):
     def _configure_fields(self) -> None:
         """
         Parses the type hints from the class extending Command and assigns each
-        a _Config field with all the necessary info to display and parse them.
+        a _Config[t.Any]field with all the necessary info to display and parse them.
         """
         annotations: dict[str, t.Any] = inspect.get_annotations(self, eval_str=True)
 
@@ -98,7 +98,7 @@ class _CommandMeta(type):
             fields[field] = value
 
             # Set the values in the class properly instead of keeping the
-            # _Config classes around
+            # _Config[t.Any]classes around
             if not value.has_default() and hasattr(self, field):
                 delattr(self, field)
             elif value.has_default():
@@ -137,7 +137,7 @@ class _CommandMeta(type):
 
 @t.dataclass_transform()
 class Command(metaclass=_CommandMeta):
-    def __init__(self, _from_parser=False) -> None:
+    def __init__(self, _from_parser: bool = False) -> None:
         if not _from_parser:
             raise ClypiException(
                 "Please, call `.parse()` on your command instead of instantiating it directly"
@@ -195,13 +195,13 @@ class Command(metaclass=_CommandMeta):
     def fields(cls) -> dict[str, _conf.Config[t.Any]]:
         """
         Parses the type hints from the class extending Command and assigns each
-        a _Config field with all the necessary info to display and parse them.
+        a Config field with all the necessary info to display and parse them.
         """
         return getattr(cls, CLYPI_FIELDS)
 
     @t.final
     @classmethod
-    def _next_positional(cls, kwargs: dict[str, t.Any]) -> Config | None:
+    def _next_positional(cls, kwargs: dict[str, t.Any]) -> Config[t.Any] | None:
         """
         Traverse the current collected arguments and find the next positional
         arg we can assign to.
@@ -245,8 +245,8 @@ class Command(metaclass=_CommandMeta):
 
     @t.final
     @classmethod
-    def options(cls) -> dict[str, Config]:
-        options: dict[str, Config] = {}
+    def options(cls) -> dict[str, Config[t.Any]]:
+        options: dict[str, Config[t.Any]] = {}
         for field, field_conf in cls.fields().items():
             if field_conf.forwarded or field_conf.is_positional:
                 continue
@@ -256,8 +256,8 @@ class Command(metaclass=_CommandMeta):
 
     @t.final
     @classmethod
-    def positionals(cls) -> dict[str, Config]:
-        positionals: dict[str, Config] = {}
+    def positionals(cls) -> dict[str, Config[t.Any]]:
+        positionals: dict[str, Config[t.Any]] = {}
         for field, field_conf in cls.fields().items():
             if field_conf.forwarded or field_conf.is_opt:
                 continue

--- a/clypi/cli.py
+++ b/clypi/cli.py
@@ -135,6 +135,7 @@ class _CommandMeta(type):
         setattr(self, CLYPI_SUBCOMMANDS, subcmds)
 
 
+@t.dataclass_transform()
 class Command(metaclass=_CommandMeta):
     def __init__(self, _from_parser=False) -> None:
         if not _from_parser:

--- a/clypi/parsers.py
+++ b/clypi/parsers.py
@@ -25,7 +25,7 @@ class Parser(t.Protocol[T]):
 
 
 class CannotParseAs(Exception):
-    def __init__(self, value: t.Any, parser: Parser) -> None:
+    def __init__(self, value: t.Any, parser: Parser[t.Any]) -> None:
         message = f"Cannot parse {value!r} as {parser}"
         super().__init__(message)
 

--- a/examples/colors.py
+++ b/examples/colors.py
@@ -16,14 +16,14 @@ def _all_colors() -> Generator[tuple[ColorType, ...], None, None]:
 
 # --- DEMO START ---
 def main() -> None:
-    fg_block = []
+    fg_block: list[str] = []
     for color, bright_color in _all_colors():
         fg_block.append(
             clypi.style("██ " + color.ljust(9), fg=color)
             + clypi.style("██ " + bright_color.ljust(16), fg=bright_color)
         )
 
-    bg_block = []
+    bg_block: list[str] = []
     for color, bright_color in _all_colors():
         bg_block.append(
             clypi.style(color.ljust(9), bg=color)
@@ -31,7 +31,7 @@ def main() -> None:
             + clypi.style(bright_color.ljust(16), bg=bright_color)
         )
 
-    style_block = []
+    style_block: list[str] = []
     style_block.append(clypi.style("I am bold", bold=True))
     style_block.append(clypi.style("I am dim", dim=True))
     style_block.append(clypi.style("I am underline", underline=True))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "clypi"
 description = "Your all-in-one for beautiful, lightweight, prod-ready CLIs"
 readme = "README.md"
-version = "1.0.12"
+version = "1.0.13"
 license = "MIT"
 license-files = ["LICEN[CS]E*"]
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,11 +43,14 @@ addopts = "-ra -q"
 testpaths = ["tests"]
 
 [tool.pyright]
-exclude = [
-    "**/__pycache__",
+include = [
+    "examples",
+    "tests",
+    "type_tests",
+    "clypi",
 ]
-# strict = ["clypi/"]
 reportMissingTypeStubs = false
+reportUninitializedInstanceVariable = true
 
 [tool.bandit]
 skips = ["B101"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,7 @@ Issues = "https://github.com/danimelchor/clypi/issues"
 [project.optional-dependencies]
 dev = [
   "ruff>=0.9.7",
-  "pyright>=1.1.396",
-  "mypy>=1.15.0",
+  "pyright[nodejs]>=1.1.396",
   "pytest>=8.3.5",
   "codespell>=2.4.1",
   "anyio>=4.8.0",
@@ -49,8 +48,11 @@ include = [
     "type_tests",
     "clypi",
 ]
-reportMissingTypeStubs = false
-reportUninitializedInstanceVariable = true
+typeCheckingMode = "strict"
+reportUnknownArgumentType = "warning"
+reportUnknownParameterType = "warning"
+reportUnknownMemberType = "warning"
+reportUnknownVariableType = "warning"
 
 [tool.bandit]
 skips = ["B101"]

--- a/tests/prompt_test.py
+++ b/tests/prompt_test.py
@@ -10,7 +10,7 @@ import pytest
 from pytest import mark
 
 import clypi
-from clypi import AbortException, MaxAttemptsException, Parser
+from clypi import AbortException, MaxAttemptsException
 from clypi.configuration import get_config
 
 
@@ -136,7 +136,7 @@ class TestCase:
             "Invalid DateTime",
         ],
     )
-    def test_prompt_with_parser_fails(self, answer: str, parser: Parser):
+    def test_prompt_with_parser_fails(self, answer: str, parser: type):
         with replace_stdin(answer) as _, pytest.raises(MaxAttemptsException):
             clypi.prompt("Some prompt", parser=parser, max_attempts=1)
 

--- a/uv.lock
+++ b/uv.lock
@@ -18,7 +18,7 @@ wheels = [
 
 [[package]]
 name = "clypi"
-version = "1.0.12"
+version = "1.0.13"
 source = { editable = "." }
 dependencies = [
     { name = "python-dateutil" },

--- a/uv.lock
+++ b/uv.lock
@@ -29,8 +29,7 @@ dependencies = [
 dev = [
     { name = "anyio" },
     { name = "codespell" },
-    { name = "mypy" },
-    { name = "pyright" },
+    { name = "pyright", extra = ["nodejs"] },
     { name = "pytest" },
     { name = "ruff" },
     { name = "types-python-dateutil" },
@@ -40,8 +39,7 @@ dev = [
 requires-dist = [
     { name = "anyio", marker = "extra == 'dev'", specifier = ">=4.8.0" },
     { name = "codespell", marker = "extra == 'dev'", specifier = ">=2.4.1" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.15.0" },
-    { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.396" },
+    { name = "pyright", extras = ["nodejs"], marker = "extra == 'dev'", specifier = ">=1.1.396" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.5" },
     { name = "python-dateutil", specifier = ">=2.9.0.post0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.9.7" },
@@ -87,52 +85,28 @@ wheels = [
 ]
 
 [[package]]
-name = "mypy"
-version = "1.15.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mypy-extensions" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ce/43/d5e49a86afa64bd3839ea0d5b9c7103487007d728e1293f52525d6d5486a/mypy-1.15.0.tar.gz", hash = "sha256:404534629d51d3efea5c800ee7c42b72a6554d6c400e6a79eafe15d11341fd43", size = 3239717 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/03/bc/f6339726c627bd7ca1ce0fa56c9ae2d0144604a319e0e339bdadafbbb599/mypy-1.15.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:2922d42e16d6de288022e5ca321cd0618b238cfc5570e0263e5ba0a77dbef56f", size = 10662338 },
-    { url = "https://files.pythonhosted.org/packages/e2/90/8dcf506ca1a09b0d17555cc00cd69aee402c203911410136cd716559efe7/mypy-1.15.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2ee2d57e01a7c35de00f4634ba1bbf015185b219e4dc5909e281016df43f5ee5", size = 9787540 },
-    { url = "https://files.pythonhosted.org/packages/05/05/a10f9479681e5da09ef2f9426f650d7b550d4bafbef683b69aad1ba87457/mypy-1.15.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:973500e0774b85d9689715feeffcc980193086551110fd678ebe1f4342fb7c5e", size = 11538051 },
-    { url = "https://files.pythonhosted.org/packages/e9/9a/1f7d18b30edd57441a6411fcbc0c6869448d1a4bacbaee60656ac0fc29c8/mypy-1.15.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a95fb17c13e29d2d5195869262f8125dfdb5c134dc8d9a9d0aecf7525b10c2c", size = 12286751 },
-    { url = "https://files.pythonhosted.org/packages/72/af/19ff499b6f1dafcaf56f9881f7a965ac2f474f69f6f618b5175b044299f5/mypy-1.15.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1905f494bfd7d85a23a88c5d97840888a7bd516545fc5aaedff0267e0bb54e2f", size = 12421783 },
-    { url = "https://files.pythonhosted.org/packages/96/39/11b57431a1f686c1aed54bf794870efe0f6aeca11aca281a0bd87a5ad42c/mypy-1.15.0-cp311-cp311-win_amd64.whl", hash = "sha256:c9817fa23833ff189db061e6d2eff49b2f3b6ed9856b4a0a73046e41932d744f", size = 9265618 },
-    { url = "https://files.pythonhosted.org/packages/98/3a/03c74331c5eb8bd025734e04c9840532226775c47a2c39b56a0c8d4f128d/mypy-1.15.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:aea39e0583d05124836ea645f412e88a5c7d0fd77a6d694b60d9b6b2d9f184fd", size = 10793981 },
-    { url = "https://files.pythonhosted.org/packages/f0/1a/41759b18f2cfd568848a37c89030aeb03534411eef981df621d8fad08a1d/mypy-1.15.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2f2147ab812b75e5b5499b01ade1f4a81489a147c01585cda36019102538615f", size = 9749175 },
-    { url = "https://files.pythonhosted.org/packages/12/7e/873481abf1ef112c582db832740f4c11b2bfa510e829d6da29b0ab8c3f9c/mypy-1.15.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ce436f4c6d218a070048ed6a44c0bbb10cd2cc5e272b29e7845f6a2f57ee4464", size = 11455675 },
-    { url = "https://files.pythonhosted.org/packages/b3/d0/92ae4cde706923a2d3f2d6c39629134063ff64b9dedca9c1388363da072d/mypy-1.15.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8023ff13985661b50a5928fc7a5ca15f3d1affb41e5f0a9952cb68ef090b31ee", size = 12410020 },
-    { url = "https://files.pythonhosted.org/packages/46/8b/df49974b337cce35f828ba6fda228152d6db45fed4c86ba56ffe442434fd/mypy-1.15.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1124a18bc11a6a62887e3e137f37f53fbae476dc36c185d549d4f837a2a6a14e", size = 12498582 },
-    { url = "https://files.pythonhosted.org/packages/13/50/da5203fcf6c53044a0b699939f31075c45ae8a4cadf538a9069b165c1050/mypy-1.15.0-cp312-cp312-win_amd64.whl", hash = "sha256:171a9ca9a40cd1843abeca0e405bc1940cd9b305eaeea2dda769ba096932bb22", size = 9366614 },
-    { url = "https://files.pythonhosted.org/packages/6a/9b/fd2e05d6ffff24d912f150b87db9e364fa8282045c875654ce7e32fffa66/mypy-1.15.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:93faf3fdb04768d44bf28693293f3904bbb555d076b781ad2530214ee53e3445", size = 10788592 },
-    { url = "https://files.pythonhosted.org/packages/74/37/b246d711c28a03ead1fd906bbc7106659aed7c089d55fe40dd58db812628/mypy-1.15.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:811aeccadfb730024c5d3e326b2fbe9249bb7413553f15499a4050f7c30e801d", size = 9753611 },
-    { url = "https://files.pythonhosted.org/packages/a6/ac/395808a92e10cfdac8003c3de9a2ab6dc7cde6c0d2a4df3df1b815ffd067/mypy-1.15.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:98b7b9b9aedb65fe628c62a6dc57f6d5088ef2dfca37903a7d9ee374d03acca5", size = 11438443 },
-    { url = "https://files.pythonhosted.org/packages/d2/8b/801aa06445d2de3895f59e476f38f3f8d610ef5d6908245f07d002676cbf/mypy-1.15.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c43a7682e24b4f576d93072216bf56eeff70d9140241f9edec0c104d0c515036", size = 12402541 },
-    { url = "https://files.pythonhosted.org/packages/c7/67/5a4268782eb77344cc613a4cf23540928e41f018a9a1ec4c6882baf20ab8/mypy-1.15.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:baefc32840a9f00babd83251560e0ae1573e2f9d1b067719479bfb0e987c6357", size = 12494348 },
-    { url = "https://files.pythonhosted.org/packages/83/3e/57bb447f7bbbfaabf1712d96f9df142624a386d98fb026a761532526057e/mypy-1.15.0-cp313-cp313-win_amd64.whl", hash = "sha256:b9378e2c00146c44793c98b8d5a61039a048e31f429fb0eb546d93f4b000bedf", size = 9373648 },
-    { url = "https://files.pythonhosted.org/packages/09/4e/a7d65c7322c510de2c409ff3828b03354a7c43f5a8ed458a7a131b41c7b9/mypy-1.15.0-py3-none-any.whl", hash = "sha256:5469affef548bd1895d86d3bf10ce2b44e33d86923c29e4d675b3e323437ea3e", size = 2221777 },
-]
-
-[[package]]
-name = "mypy-extensions"
-version = "1.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/98/a4/1ab47638b92648243faf97a5aeb6ea83059cc3624972ab6b8d2316078d3f/mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782", size = 4433 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/e2/5d3f6ada4297caebe1a2add3b126fe800c96f56dbe5d1988a2cbe0b267aa/mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d", size = 4695 },
-]
-
-[[package]]
 name = "nodeenv"
 version = "1.9.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314 },
+]
+
+[[package]]
+name = "nodejs-wheel-binaries"
+version = "22.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/c7/4fd3871d2b7fd5122216245e273201ab98eda92bbd6fe9ad04846b758c56/nodejs_wheel_binaries-22.14.0.tar.gz", hash = "sha256:c1dc43713598c7310d53795c764beead861b8c5021fe4b1366cb912ce1a4c8bf", size = 8055 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/b6/66ef4ef75ea7389ea788f2d5505bf9a8e5c3806d56c7a90cf46a6942f1cf/nodejs_wheel_binaries-22.14.0-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:d8ab8690516a3e98458041286e3f0d6458de176d15c14f205c3ea2972131420d", size = 50326597 },
+    { url = "https://files.pythonhosted.org/packages/7d/78/023d91a293ba73572a643bc89d11620d189f35f205a309dd8296aa45e69a/nodejs_wheel_binaries-22.14.0-py2.py3-none-macosx_11_0_x86_64.whl", hash = "sha256:b2f200f23b3610bdbee01cf136279e005ffdf8ee74557aa46c0940a7867956f6", size = 51158258 },
+    { url = "https://files.pythonhosted.org/packages/af/86/324f6342c79e5034a13319b02ba9ed1f4ac8813af567d223c9a9e56cd338/nodejs_wheel_binaries-22.14.0-py2.py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d0877832abd7a9c75c8c5caafa37f986c9341ee025043c2771213d70c4c1defa", size = 57180264 },
+    { url = "https://files.pythonhosted.org/packages/6d/9f/42bdaab26137e31732bff00147b9aca2185d475b5752b57a443e6c7ba93f/nodejs_wheel_binaries-22.14.0-py2.py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8fded5a70a8a55c2135e67bd580d8b7f2e94fcbafcc679b6a2d5b92f88373d69", size = 57693251 },
+    { url = "https://files.pythonhosted.org/packages/ab/d7/94f8f269aa86cf35f9ed2b70d09aca48dc971fb5656fdc4a3b69364b189f/nodejs_wheel_binaries-22.14.0-py2.py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:c1ade6f3ece458b40c02e89c91d5103792a9f18aaad5026da533eb0dcb87090e", size = 58841717 },
+    { url = "https://files.pythonhosted.org/packages/2d/a0/43b7316eaf22b4ee9bfb897ee36c724efceac7b89d7d1bedca28057b7be1/nodejs_wheel_binaries-22.14.0-py2.py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:34fa5ed4cf3f65cbfbe9b45c407ffc2fc7d97a06cd8993e6162191ff81f29f48", size = 59808791 },
+    { url = "https://files.pythonhosted.org/packages/10/0a/814491f751a25136e37de68a2728c9a9e3c1d20494aba5ff3c230d5f9c2d/nodejs_wheel_binaries-22.14.0-py2.py3-none-win_amd64.whl", hash = "sha256:ca7023276327455988b81390fa6bbfa5191c1da7fc45bc57c7abc281ba9967e9", size = 40478921 },
+    { url = "https://files.pythonhosted.org/packages/f4/5c/cab444afaa387dceac8debb817b52fd00596efcd2d54506c27311c6fe6a8/nodejs_wheel_binaries-22.14.0-py2.py3-none-win_arm64.whl", hash = "sha256:fd59c8e9a202221e316febe1624a1ae3b42775b7fb27737bf12ec79565983eaf", size = 36206637 },
 ]
 
 [[package]]
@@ -164,6 +138,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/bd/73/f20cb1dea1bdc1774e7f860fb69dc0718c7d8dea854a345faec845eb086a/pyright-1.1.396.tar.gz", hash = "sha256:142901f5908f5a0895be3d3befcc18bedcdb8cc1798deecaec86ef7233a29b03", size = 3814400 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/80/be/ecb7cfb42d242b7ee764b52e6ff4782beeec00e3b943a3ec832b281f9da6/pyright-1.1.396-py3-none-any.whl", hash = "sha256:c635e473095b9138c471abccca22b9fedbe63858e0b40d4fc4b67da041891844", size = 5689355 },
+]
+
+[package.optional-dependencies]
+nodejs = [
+    { name = "nodejs-wheel-binaries" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR introduces strict type checking (except a couple rules) for all the repo. I fixed type issues, removed `mypy` because it conflicts on it's type checking for async functions from Pyright which is impossible to handle, and added a `@t.dataclass_transform()` to `Command` so that it's interpreted as a dataclass which lets users have non-default args.