### PR TITLE
Bug - Fix field validation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "clypi"
 description = "Your all-in-one for beautiful, lightweight, prod-ready CLIs"
 readme = "README.md"
-version = "1.0.18"
+version = "1.0.19"
 license = "MIT"
 license-files = ["LICEN[CS]E*"]
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -18,7 +18,7 @@ wheels = [
 
 [[package]]
 name = "clypi"
-version = "1.0.18"
+version = "1.0.19"
 source = { editable = "." }
 dependencies = [
     { name = "python-dateutil" },


### PR DESCRIPTION
In https://github.com/danimelchor/clypi/pull/76 I moved part of the parsing logic to `__init__` since it's called to parse commands. However, this breaks forwarded arguments since we're not failing as early as we were before. 

For example, if a forwarded argument is missing, we're now doing it during class instantiation. This means that we're doing it **after** we parse the subcommands, so the error displayed actually comes from the forwarded field missing and not from the parent command which required the field in the first place.