### PR TITLE
Feat - Per-arg negative opt

### DIFF
--- a/clypi/_cli/arg_config.py
+++ b/clypi/_cli/arg_config.py
@@ -42,8 +42,8 @@ class PartialConfig(t.Generic[T]):
     inherited: bool = False
     hidden: bool = False
     group: str | None = None
-    defer: bool = False
     negative: str | None = None
+    defer: bool = False
 
 
 @dataclass
@@ -61,8 +61,8 @@ class Config(t.Generic[T]):
     inherited: bool = False
     hidden: bool = False
     group: str | None = None
-    defer: bool = False
     negative: str | None = None
+    defer: bool = False
 
     def __post_init__(self):
         if self.is_positional and self.short:
@@ -162,8 +162,8 @@ def arg(
     inherited: bool = False,
     hidden: bool = False,
     group: str | None = None,
-    defer: bool = False,
     negative: str | None = None,
+    defer: bool = False,
 ) -> T:
     return PartialConfig(
         default=default,
@@ -177,8 +177,8 @@ def arg(
         inherited=inherited,
         hidden=hidden,
         group=group,
-        defer=defer,
         negative=negative,
+        defer=defer,
     )  # type: ignore
 
 

--- a/clypi/_cli/arg_config.py
+++ b/clypi/_cli/arg_config.py
@@ -43,6 +43,7 @@ class PartialConfig(t.Generic[T]):
     hidden: bool = False
     group: str | None = None
     defer: bool = False
+    negative: str | None = None
 
 
 @dataclass
@@ -61,6 +62,7 @@ class Config(t.Generic[T]):
     hidden: bool = False
     group: str | None = None
     defer: bool = False
+    negative: str | None = None
 
     def __post_init__(self):
         if self.is_positional and self.short:
@@ -108,8 +110,9 @@ class Config(t.Generic[T]):
     @property
     def negative_name(self):
         assert self.is_opt, "negative_name can only be used for options"
-        name = arg_parser.snake_to_dash(self.name)
-        return f"--no-{name}"
+        assert self.negative, "negative is not set"
+        negative_name = arg_parser.snake_to_dash(self.negative)
+        return f"--{negative_name}"
 
     @property
     def short_display_name(self):
@@ -160,6 +163,7 @@ def arg(
     hidden: bool = False,
     group: str | None = None,
     defer: bool = False,
+    negative: str | None = None,
 ) -> T:
     return PartialConfig(
         default=default,
@@ -174,6 +178,7 @@ def arg(
         hidden=hidden,
         group=group,
         defer=defer,
+        negative=negative,
     )  # type: ignore
 
 

--- a/clypi/_cli/formatter.py
+++ b/clypi/_cli/formatter.py
@@ -82,8 +82,6 @@ class ClypiFormatter:
         return self.theme.placeholder(f"<{placeholder}>")
 
     def _format_option(self, option: Config[t.Any]) -> tuple[str, ...]:
-        from clypi._configuration import get_config
-
         help = self._maybe_norm_help(option.help or "")
 
         # E.g.: -r, --requirements <REQUIREMENTS>
@@ -94,7 +92,7 @@ class ClypiFormatter:
             usage = short_usage + ", " + usage
 
         # E.g.: --flag/--no-flag
-        if get_config().negative_flags:
+        if option.negative:
             usage += "/" + self.theme.long_option(option.negative_name)
 
         if not self.show_option_types:

--- a/clypi/_configuration.py
+++ b/clypi/_configuration.py
@@ -55,9 +55,6 @@ class ClypiConfig:
     # If we cannot get the terminal size, what should be the fallback?
     fallback_term_width: int = 100
 
-    # Enable negative flags (e.g.: --flag/--no-flag)
-    negative_flags: bool = False
-
 
 _config = ClypiConfig()
 

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -10,6 +10,7 @@ def arg(
     prompt: str | None = None,
     hide_input: bool = False,
     max_attempts: int = MAX_ATTEMPTS,
+    negative: str | None = None,
     group: str | None = None,
 ) -> T
 ```
@@ -28,6 +29,7 @@ Parameters:
 - `hide_input`: whether the input shouldn't be displayed as the user types (for passwords, API keys, etc.)
 - `max_attempts`: how many times to ask the user before giving up and raising
 - `group`: optionally define the name of a group to display the option in. Adding an option will automatically display the options in a different section of the help page (see the [Argument groups](../learn/getting_started.md#argument-groups) docs).
+- `negative`: defines the negative argument to set a flag as False. Useful for flags that have prompts so that they can be programmatically set to False.
 - `defer` (advanced): defers the fetching of a value until the value is used. This can be helpful to express complex dependencies between arguments. For example, you may not want to prompt if a different option was passed in (see `examples/cli_deferred.py`).
 
 ## `Command`

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -79,7 +79,7 @@ class MyCommand(Command):
 
 Arguments are mandatory positional words the user must pass in. They're defined as class attributes with no default and type hinted with the `Positional[T]` type.
 
-<!-- mdtest -->
+<!-- mdtest-args 5 foo bar baz -->
 ```python hl_lines="6 7"
 from clypi import Command, Positional
 
@@ -88,6 +88,9 @@ from clypi import Command, Positional
 class MyCommand(Command):
     arg1: Positional[int]
     arg2: Positional[list[str]]
+
+main = MyCommand.parse()
+main.start()
 ```
 
 ### Flags
@@ -104,8 +107,28 @@ from clypi import Command
 # With the flag OFF: my-command
 class MyCommand(Command):
     my_flag: bool = False
+
+main = MyCommand.parse()
+main.start()
 ```
 
+#### Negative flags
+
+You can define negative flag names for each flag using our handy `arg` helper and `negative`. This will configure an option users can pass that will set the flag to False. This is useful for flags that prompt so that they can be set to any value from the command line:
+
+<!-- mdtest-args --no-my-flag -->
+```python hl_lines="7"
+from clypi import Command, arg
+
+# With the flag ON: my-command --my-flag
+# With the flag OFF: my-command --no-my-flag
+# With no value: will prompt
+class MyCommand(Command):
+    my_flag: bool = arg(False, prompt="Value for my-flag?", negative="no_my_flag")
+
+main = MyCommand.parse()
+main.start()
+```
 
 ### Options
 
@@ -119,6 +142,9 @@ from clypi import Command
 # With default: my-command
 class MyCommand(Command):
     my_attr: str | int = "some-default-here"
+
+main = MyCommand.parse()
+main.start()
 ```
 
 ### Running the command
@@ -137,11 +163,14 @@ class MyCommand(Command):
     @override
     async def run(self):
         print(f"Running with verbose: {self.verbose}")
+
+main = MyCommand.parse()
+main.start()
 ```
 
 ### Help page
 
-You can define custom help messages for each argument using our handy `config` helper:
+You can define custom help messages for each argument using our handy `arg` helper:
 
 <!-- mdtest -->
 ```python hl_lines="6"
@@ -152,6 +181,9 @@ class MyCommand(Command):
         True,
         help="Whether to show all of the output"
     )
+
+main = MyCommand.parse()
+main.start()
 ```
 
 You can also define custom help messages for commands by creating a docstring on the class itself:
@@ -164,21 +196,27 @@ class MyCommand(Command):
     This text will show up when someone does `my-command --help`
     and can contain any info you'd like
     """
+
+main = MyCommand.parse()
+main.start()
 ```
 
 ### Prompting
 
-If you want to ask the user to provide input if it's not specified, you can pass in a prompt to `config` for each field like so:
+If you want to ask the user to provide input if it's not specified, you can pass in a prompt to `arg` for each field like so:
 
-<!-- mdtest -->
+<!-- mdtest-stdin foo -->
 ```python hl_lines="4"
 from clypi import Command, arg
 
 class MyCommand(Command):
     name: str = arg(prompt="What's your name?")
+
+main = MyCommand.parse()
+main.start()
 ```
 
-On runtime, if the user didn't provide a value for `--name`, the program will ask the user to provide one until they do. You can also pass in a `default` value to `config` to allow the user to just hit enter to accept the default.
+On runtime, if the user didn't provide a value for `--name`, the program will ask the user to provide one until they do. You can also pass in a `default` value to `arg` to allow the user to just hit enter to accept the default.
 
 ### Autocomplete
 
@@ -295,7 +333,7 @@ import logging
 from typing_extensions import override
 from clypi import Command
 
-class Main(Command):
+class MyCommand(Command):
     @override
     async def pre_run_hook(self):
         cmd_str = " ".join(self.full_command())
@@ -305,7 +343,7 @@ class Main(Command):
     async def run(self):
         print("Hey")
 
-main = Main.parse()
+main = MyCommand.parse()
 main.start()
 ```
 

--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -38,7 +38,6 @@ ClypiConfig(
     overflow_style="wrap",
     disable_colors=False,
     fallback_term_width=100,
-    negative_flags=False,
 )
 ```
 
@@ -51,4 +50,3 @@ Parameters:
 - `overflow_style`: either `wrap` or `ellipsis`. If wrap, text that is too long will get wrapped into the next line. If ellipsis, the text will be truncated with an `…` at the end
 - <!-- md:version 1.2.11 --> `disable_colors`: whether we should disable all colors and text styles
 - <!-- md:version 1.2.11 --> `fallback_term_width`: if we cannot get the current terminal width (e.g.: subprocesses, non-tty devices, etc.), what should the fallback terminal width be (mostly used for displaying errors)
-- <!-- md:version 1.2.19 --> `negative_flags`: enable negative flags (e.g.: `--flag`/`--no-flag`). Useful if you make your flag prompt so that it can still be accessed programmatically

--- a/examples/cli_negative_flags.py
+++ b/examples/cli_negative_flags.py
@@ -1,16 +1,16 @@
 from typing_extensions import override
 
-from clypi import Command, arg, cprint, get_config, style
+from clypi import Command, arg, cprint, style
 
 
 class Main(Command):
     """An example of how enabling negative flags looks like"""
 
     verbose: bool = arg(
-        False,
+        True,
         short="v",
+        negative="quiet",
         help="Whether to show more output",
-        prompt="Should we show more output?",
     )
 
     @override
@@ -18,13 +18,12 @@ class Main(Command):
         cprint(f"Verbose: {self.verbose}", fg="blue")
         print(
             style("Try using ", fg="cyan")
-            + style("--no-verbose", fg="yellow", bold=True)
+            + style("--quiet", fg="yellow", bold=True)
             + style(" or ", fg="cyan")
             + style("--help", fg="yellow", bold=True)
         )
 
 
 if __name__ == "__main__":
-    get_config().negative_flags = True
     main: Main = Main.parse()
     main.start()

--- a/mdtest/__main__.py
+++ b/mdtest/__main__.py
@@ -2,13 +2,13 @@ import asyncio
 import re
 import shutil
 import time
+import tomllib
 from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
 from textwrap import dedent
 
 import anyio
-import tomllib
 from typing_extensions import override
 
 import clypi.parsers as cp
@@ -117,6 +117,9 @@ async def parse_file(sm: asyncio.Semaphore, file: Path) -> list[Test]:
             # Mdtest generic definition
             elif g := re.search("<!-- mdtest -->", line):
                 in_test = True
+
+            elif "mdtest" in line:
+                raise ValueError(f"Invalid mdtest config line: {line}")
 
     sm.release()
     cprint(style("✔", fg="green") + f" Collected {len(tests)} tests for {file}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "clypi"
 description = "Your all-in-one for beautiful, lightweight, prod-ready CLIs"
 readme = "README.md"
-version = "1.2.20"
+version = "1.2.21"
 license = "MIT"
 license-files = ["LICEN[CS]E*"]
 requires-python = ">=3.11"

--- a/tests/cli_parse_test.py
+++ b/tests/cli_parse_test.py
@@ -18,7 +18,6 @@ def parametrize(args: str, cases: list[tuple[t.Any, ...]]):
 
 
 get_config().help_on_fail = False
-get_config().negative_flags = True
 
 
 def join_mult(s: str, n: int):

--- a/tests/cli_parse_test.py
+++ b/tests/cli_parse_test.py
@@ -71,7 +71,7 @@ class ExampleSub(Command):
 
 class Example(Command):
     pos: Positional[Path]
-    flag: bool = arg(False, short="f")
+    flag: bool = arg(False, short="f", negative="no_flag")
     subcommand: ExampleSub | None = None
     option: list[str] = arg(default_factory=list, short="o")
 

--- a/uv.lock
+++ b/uv.lock
@@ -109,7 +109,7 @@ wheels = [
 
 [[package]]
 name = "clypi"
-version = "1.2.20"
+version = "1.2.21"
 source = { editable = "." }
 dependencies = [
     { name = "python-dateutil" },


### PR DESCRIPTION
Reverts the last change to set per-arg negative flags. I thought about it, and globally negative values don't make too much sense. Plus, sometimes it's not as easy as `--no-{flag}`, like `––verbose/--quiet`.