### PR TITLE
Feat - Nicer formatted exceptions with exception groups

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,5 +73,5 @@ repos:
       entry: uv run mdtest
       language: python
       pass_filenames: false
-      always_run: true
       stages: [pre-push]
+      types: [markdown]

--- a/clypi/_configuration.py
+++ b/clypi/_configuration.py
@@ -5,6 +5,7 @@ from clypi._colors import Styler
 from clypi._components.wraps import OverflowStyle
 from clypi._exceptions import (
     ClypiException,
+    ClypiExceptionGroup,
 )
 
 
@@ -42,8 +43,8 @@ class ClypiConfig:
     help_on_fail: bool = True
 
     # What errors should we catch and neatly display?
-    nice_errors: tuple[type[Exception]] = field(
-        default_factory=lambda: (ClypiException,)
+    nice_errors: tuple[type[Exception], ...] = field(
+        default_factory=lambda: (ClypiException, ClypiExceptionGroup)
     )
 
     # How should sentences overwrap if they're too long?

--- a/clypi/_exceptions.py
+++ b/clypi/_exceptions.py
@@ -1,7 +1,14 @@
+import typing as t
+from dataclasses import dataclass, field
+
 from clypi._colors import ColorType, style
 
 
 class ClypiException(Exception):
+    pass
+
+
+class ClypiExceptionGroup(ExceptionGroup):
     pass
 
 
@@ -13,20 +20,56 @@ class AbortException(ClypiException):
     pass
 
 
-def format_traceback(err: BaseException, color: ColorType | None = "red") -> list[str]:
-    # Get the traceback bottom up
-    tb: list[BaseException] = [err]
-    while tb[-1].__cause__ is not None:
-        tb.append(tb[-1].__cause__)
+@dataclass
+class TreeExcNode:
+    exc: BaseException
+    children: list[t.Self] = field(default_factory=list)
 
-    lines: list[str] = []
-    for i, e in enumerate(reversed(tb)):
-        icon = "  " * (i - 1) + " ↳ " if i != 0 else ""
-        s = style(f"{icon}{str(e)}", fg=color)
-        lines.append(s)
+
+def _build_exc_tree(err: BaseException) -> TreeExcNode:
+    root = TreeExcNode(err)
+
+    # Add __cause__ levels
+    if err.__cause__ is not None:
+        root.children.append(_build_exc_tree(err.__cause__))
+
+    # Add exception group levels
+    if isinstance(err, ExceptionGroup):
+        for sub_exc in err.exceptions:
+            root.children.append(_build_exc_tree(sub_exc))
+
+    return root
+
+
+def format_traceback(err: BaseException, color: ColorType | None = "red") -> list[str]:
+    def _format_exc(e: BaseException, indent: int):
+        msg, *_ = e.args
+        icon = "  " * (indent - 1) + " ↳ " if indent != 0 else ""
+        return style(f"{icon}{str(msg)}", fg=color)
+
+    def _print_level(tree: TreeExcNode, indent: int) -> list[str]:
+        ret: list[str] = []
+        for child_node in tree.children:
+            ret.append(_format_exc(child_node.exc, indent))
+            ret.extend(_print_level(child_node, indent=indent + 1))
+        return ret
+
+    tree = _build_exc_tree(err)
+    lines = [_format_exc(tree.exc, indent=0)]
+    lines.extend(_print_level(tree, indent=1))
     return lines
 
 
 def print_traceback(err: BaseException) -> None:
     for line in format_traceback(err):
         print(line)
+
+
+def flatten_exc(err: Exception) -> list[Exception]:
+    if not isinstance(err, ExceptionGroup):
+        return [err]
+
+    result: list[Exception] = []
+    for sub_err in err.exceptions:
+        result.extend(flatten_exc(sub_err))
+    return result

--- a/clypi/parsers.py
+++ b/clypi/parsers.py
@@ -426,7 +426,7 @@ class Union(ClypiParser[t.Union[X, Y]]):
         except CATCH_ERRORS as e:
             first_exc = e
 
-        # Try parsing as the second side of the union
+        # Try parsing as the right side of the union
         try:
             return second(raw)
         except CATCH_ERRORS as e:

--- a/clypi/parsers.py
+++ b/clypi/parsers.py
@@ -12,7 +12,7 @@ from pathlib import Path as _Path
 from typing_extensions import override
 
 from clypi import _type_util as tu
-from clypi._exceptions import ClypiException
+from clypi._exceptions import ClypiException, ClypiExceptionGroup, flatten_exc
 from clypi._util import UNSET, Unset, trim_split_collection
 
 T = t.TypeVar("T", covariant=True)
@@ -33,6 +33,7 @@ CATCH_ERRORS: tuple[type[Exception], ...] = (
     TypeError,
     IndexError,
     ClypiException,
+    ClypiExceptionGroup,
 )
 
 
@@ -40,6 +41,18 @@ class CannotParseAs(ClypiException):
     def __init__(self, value: t.Any, parser: Parser[t.Any]) -> None:
         message = f"Cannot parse {value!r} as {parser}"
         super().__init__(message)
+
+
+class CannotParseAsGroup(ClypiExceptionGroup):
+    @classmethod
+    def get(
+        cls,
+        value: t.Any,
+        parser: Parser[t.Any],
+        exceptions: t.Sequence[Exception],
+    ) -> t.Self:
+        message = f"Cannot parse {value!r} as {parser}"
+        return cls(message, exceptions)
 
 
 class ClypiParser(ABC, t.Generic[X]):
@@ -405,11 +418,28 @@ class Union(ClypiParser[t.Union[X, Y]]):
         if isinstance(first, Str):
             first, second = self._right, self._left
 
-        with suppress(*CATCH_ERRORS):
+        first_exc, second_exc = None, None
+
+        # Try parsing as the left side of the union
+        try:
             return first(raw)
-        with suppress(*CATCH_ERRORS):
+        except CATCH_ERRORS as e:
+            first_exc = e
+
+        # Try parsing as the second side of the union
+        try:
             return second(raw)
-        raise CannotParseAs(raw, self)
+        except CATCH_ERRORS as e:
+            second_exc = e
+
+        raise CannotParseAsGroup.get(
+            raw,
+            self,
+            [
+                *flatten_exc(first_exc),
+                *flatten_exc(second_exc),
+            ],
+        )
 
     def _parts(self):
         """

--- a/examples/cli_custom_parser.py
+++ b/examples/cli_custom_parser.py
@@ -1,0 +1,44 @@
+import re
+
+from typing_extensions import override
+
+import clypi.parsers as cp
+from clypi import Command, arg, cprint
+
+
+class SlackChannel(cp.Str):
+    @override
+    def __call__(self, raw: str | list[str], /) -> str:
+        parsed = super().__call__(raw)
+        if not re.match(r"#[a-z0-9-]+", parsed):
+            raise ValueError("Invalid slack channel")
+        return parsed
+
+
+class SlackChannelId(cp.Int):
+    @override
+    def __call__(self, raw: str | list[str], /) -> int:
+        parsed = super().__call__(raw)
+        if parsed < 1_000_000 or parsed > 9_999_999:
+            raise ValueError(f"Invalid Slack channel {parsed}, it must be 8 digits")
+        return parsed
+
+
+class Main(Command):
+    """An example of how useful custom parsers can be"""
+
+    slack: str | int | None = arg(
+        help="The Slack channel to send notifications to",
+        prompt="What Slack channel should we send notifications to?",
+        parser=SlackChannel() | SlackChannelId() | cp.NoneParser(),
+    )
+
+    @override
+    async def run(self):
+        cprint(f"Slack: {self.slack} ({type(self.slack)})", fg="blue")
+        cprint("Try using a valid or invalid slack channel", fg="cyan")
+
+
+if __name__ == "__main__":
+    main: Main = Main.parse()
+    main.start()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "clypi"
 description = "Your all-in-one for beautiful, lightweight, prod-ready CLIs"
 readme = "README.md"
-version = "1.3.0"
+version = "1.4.0"
 license = "MIT"
 license-files = ["LICEN[CS]E*"]
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,9 @@ docs = [
   "termynal>=0.13.0",
 ]
 
+[tool.ruff]
+target-version = "py311"
+
 [tool.pytest.ini_options]
 minversion = "8.0"
 addopts = "-ra -q"

--- a/tests/exceptions_test.py
+++ b/tests/exceptions_test.py
@@ -1,0 +1,74 @@
+from textwrap import dedent
+
+from clypi import format_traceback
+from clypi._exceptions import ClypiExceptionGroup
+
+
+def test_basic_traceback():
+    root_cause = RuntimeError("Actual root cause")
+
+    context = ValueError("Some context")
+    context.__cause__ = root_cause
+
+    err = ValueError("User facing error")
+    err.__cause__ = context
+
+    result = format_traceback(err, color=None)
+    result_str = "\n".join(result)
+    assert (
+        result_str
+        == dedent(
+            """
+            User facing error
+             ↳ Some context
+               ↳ Actual root cause
+            """
+        ).strip()
+    )
+
+
+def test_traceback_exc_group():
+    context1 = ValueError("Failed to parse 'foo' as int()")
+    context2 = ValueError("Failed to parse 'foo' as None")
+    err = ClypiExceptionGroup("Failed to parse as int|none", [context1, context2])
+
+    result = format_traceback(err, color=None)
+    result_str = "\n".join(result)
+    assert (
+        result_str
+        == dedent(
+            """
+            Failed to parse as int|none
+             ↳ Failed to parse 'foo' as int()
+             ↳ Failed to parse 'foo' as None
+            """
+        ).strip()
+    )
+
+
+def test_traceback_complex():
+    root1 = ValueError("Invalid int literal for base 10 'foo'")
+    context1 = ValueError("Failed to parse 'foo' as int()")
+    context1.__cause__ = root1
+
+    root2_1 = ValueError("Text 'foo' does not match 'none'")
+    root2_2 = ValueError("Text 'foo' is not an empty list")
+    context2 = ClypiExceptionGroup("Failed to parse 'foo' as None", [root2_1, root2_2])
+
+    err = ClypiExceptionGroup("Failed to parse as int|none", [context1, context2])
+
+    result = format_traceback(err, color=None)
+    result_str = "\n".join(result)
+    assert (
+        result_str
+        == dedent(
+            """
+            Failed to parse as int|none
+             ↳ Failed to parse 'foo' as int()
+               ↳ Invalid int literal for base 10 'foo'
+             ↳ Failed to parse 'foo' as None
+               ↳ Text 'foo' does not match 'none'
+               ↳ Text 'foo' is not an empty list
+            """
+        ).strip()
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -109,7 +109,7 @@ wheels = [
 
 [[package]]
 name = "clypi"
-version = "1.3.0"
+version = "1.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "python-dateutil" },


### PR DESCRIPTION
Before:
```
Cannot parse 'foo' as (text|integer|none)
```

After:
```
Cannot parse 'foo' as (text|integer|none)
 ↳ invalid literal for int() with base 10: 'foo'
 ↳ Invalid slack channel
 ↳ Cannot parse 'foo' as none
```

Since, without exception groups, there was no way to neatly nest exceptions with multiple causes which meant parsers like `Union` couldn't display an exception properly.